### PR TITLE
SAN-6391: Fixed NullPointerException caused by the purchases array on onPurchasesUpdated

### DIFF
--- a/src/android/cc/fovea/PurchasePlugin.java
+++ b/src/android/cc/fovea/PurchasePlugin.java
@@ -401,13 +401,15 @@ public class PurchasePlugin
     try {
       final int code = result.getResponseCode();
       if (code == BillingResponseCode.OK) {
-        Log.d(mTag, "onPurchasesUpdated() -> Success");
-        for (Purchase p : purchases) {
-          mPurchases.add(0, p);
+        if (purchases != null) {
+          Log.d(mTag, "onPurchasesUpdated() -> Success");
+          for (Purchase p : purchases) {
+            mPurchases.add(0, p);
+          }
+          callSuccess();
+          sendToListener("purchasesUpdated", new JSONObject()
+              .put("purchases", toJSON(purchases)));
         }
-        callSuccess();
-        sendToListener("purchasesUpdated", new JSONObject()
-            .put("purchases", toJSON(purchases)));
       }
       else if (code == BillingResponseCode.USER_CANCELED) {
         Log.w(mTag, "onPurchasesUpdated() -> "


### PR DESCRIPTION
This fixes [SAN-6391](https://sanvello.atlassian.net/browse/SAN-6391)

`onPurchasesUpdated` callback gets called with `BillingClient.BillingResponseCode.OK` but the purchases list passed in the callback is empty which throws a `NullPointerException`.

Exception:
```
com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)        at 
com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)     Caused by: java.lang.NullPointerException: Attempt to 
invoke interface method 'java.util.Iterator java.util.List.iterator()' on a null object reference        at 
cc.fovea.PurchasePlugin.onPurchasesUpdated(PurchasePlugin.java:405)        at 
com.android.billingclient.api.zze.onReceive(com.android.billingclient:billing@@3.0.0:15)        at 
android.app.LoadedApk$ReceiverDispatcher$Args.lambda$-
android_app_LoadedApk$ReceiverDispatcher$Args_52497(LoadedApk.java:1313)        at 
android.app.-$Lambda$aS31cHIhRx41653CMnd4gZqshIQ.$m$7(Unknown Source:4)        at 
android.app.-$Lambda$aS31cHIhRx41653CMnd4gZqshIQ.run(Unknown Source:39)        at 
android.os.Handler.handleCallback(Handler.java:790)        at android.os.Handler.dispatchMessage(Handler.java:99)        at 
android.os.Looper.loop(Looper.java:164)        at android.app.ActivityThread.main(ActivityThread.java:6494)        at 
java.lang.reflect.Method.invoke(Native Method)
```

References to the same issue in another project:
https://github.com/android/play-billing-samples/issues/127